### PR TITLE
Fix dorth_infty method

### DIFF
--- a/potrace/potrace.py
+++ b/potrace/potrace.py
@@ -883,7 +883,7 @@ def dorth_infty(p0: _Point, p2: _Point):
     return a direction that is 90 degrees counterclockwise from p2-p0,
     but then restricted to one of the major wind directions (n, nw, w, etc)
     """
-    return _Point(sign(p2.x - p0.x), -sign(p2.y - p0.y))
+    return _Point(-sign(p2.y - p0.y), sign(p2.x - p0.x))
 
 
 def dpara(p0: _Point, p1: _Point, p2: _Point) -> float:


### PR DESCRIPTION
The same method from Potrace 1.16 source:

```C
/* return a direction that is 90 degrees counterclockwise from p2-p0,
   but then restricted to one of the major wind directions (n, nw, w, etc) */
static inline point_t dorth_infty(dpoint_t p0, dpoint_t p2) {
  point_t r;
  
  r.y = sign(p2.x-p0.x);
  r.x = -sign(p2.y-p0.y);

  return r;
}
```