### PR TITLE
~2x speedup using numba decorator in one single place

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,17 @@ or:
 
 The cli project contains valid console script entrypoints for potrace. If you install the command-line package it will add `potracer` to your console scripts. Note the `-r` suffix so that it does not interfere with potrace that may be otherwise installed.
 
+### Numba (optional, experimental)
+[numba](https://github.com/numba/numba), an open source jit compiler for python & numpy, has been shown to speed up python potrace considerably (for complex images approx. a factor of 2).
+While numba supports most [platforms](https://numba.pydata.org/numba-doc/latest/user/installing.html#compatibility), it does not support _every_ platform that can run python.
+Depending on your requirements for runtime and depending on your platform, it might be worth to try.
+
+__By default, numba is disabled.__ Potrace with numba enabled can be installed with:
+
+* `pip install potracer[numba]`
+
+to make use of the speedup.
+
 # Requirements
 * numpy: for bitmap structures.
 

--- a/potrace/potrace.py
+++ b/potrace/potrace.py
@@ -3,6 +3,14 @@ from typing import Optional, Tuple, Union
 
 import numpy as np
 
+try:
+    from numba import njit
+except ImportError:
+
+    def njit(*args, **kwargs):
+        return lambda f: f
+
+
 POTRACE_TURNPOLICY_BLACK = 0
 POTRACE_TURNPOLICY_WHITE = 1
 POTRACE_TURNPOLICY_LEFT = 2
@@ -641,6 +649,7 @@ def findpath(bm: np.array, x0: int, y0: int, sign: bool, turnpolicy: int) -> _Pa
     return _Path(pt, area, sign)
 
 
+@njit()
 def findnext(bm: np.array) -> Optional[Tuple[Union[int], int]]:
     """
     /* find the next set pixel in a row <= y. Pixels are searched first
@@ -1262,7 +1271,7 @@ def _calc_lon(pp: _Path) -> int:
         dk_y = sign(pt[k].y - pt[k1].y)
         cur_x = pt[k1].x - pt[i].x
         cur_y = pt[k1].y - pt[i].y
-        """find largest integer j such that xprod(constraint[0], cur+j*dk) >= 0 
+        """find largest integer j such that xprod(constraint[0], cur+j*dk) >= 0
         and xprod(constraint[1], cur+j*dk) <= 0. Use bilinearity of xprod. */"""
         a = xprod(constraint0x, constraint0y, cur_x, cur_y)
         b = xprod(constraint0x, constraint0y, dk_x, dk_y)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = potracer
-version = 0.0.4
+version = 0.0.5
 description = Python Potrace
 long_description_content_type=text/markdown
 long_description = file: README.md

--- a/setup.py
+++ b/setup.py
@@ -5,5 +5,6 @@ setup(
     ],
     extras_require={
         'cli': ["potrace-cli"],
+        'numba': ["numba"],
     }
 )


### PR DESCRIPTION
Thanks a lot for this pure python port of potrace!

Looking at cProfile results, I saw that `findnext()` is a performance hotspot. By introducing numba, and adding  a single `numba.njit()` decorator to `findnext`, a 2x speedup is achieved. I am sure there is a lot more possible, this is just the lowest of the low hanging fruits.

I did not touch the default installation and only added numba as an optional dependency. Users with the need for more performance can install using `pip install potracer[numba]`. I updated the Readme.md accordingly.


**Profiling results:**
I used this image to test: [link](https://drawingdatabase.com/wp-content/uploads/2014/04/SR-71-BlackBird.jpeg), and was able to reduce the runtime from ~60 seconds to ~26 seconds.

**Before:**
```
44505289 function calls (43271614 primitive calls) in 61.255 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    154/1    0.000    0.000   61.266   61.266 {built-in method builtins.exec}
        1    0.069    0.069   61.266   61.266 test.py:1(<module>)
        1    0.076    0.076   61.069   61.069 test.py:6(file_to_svg)
        1    0.000    0.000   60.926   60.926 potrace.py:39(trace)
        1    0.020    0.020   46.160   46.160 potrace.py:810(bm_to_pathlist)
     3993    2.480    0.001   44.978    0.011 potrace.py:644(findnext)            <-- ~45 seconds spent here
     3993    0.006    0.000   42.493    0.011 fromnumeric.py:1881(nonzero)
     3994    0.008    0.000   42.487    0.011 fromnumeric.py:53(_wrapfunc)
     3993   42.478    0.011   42.478    0.011 {method 'nonzero' of 'numpy.ndarray' objects}
        1    0.021    0.021   14.734   14.734 potrace.py:1921(process_path)
     2988    7.397    0.002   10.508    0.004 potrace.py:1169(_calc_lon)
     2988    0.513    0.000    2.736    0.001 potrace.py:1348(_bestpolygon)
  1185378    1.745    0.000    2.159    0.000 potrace.py:1305(penalty3)
 15840196    1.517    0.000    1.517    0.000 potrace.py:1007(xprod)
     3992    0.680    0.000    0.926    0.000 potrace.py:570(findpath)
  8628578    0.773    0.000    0.773    0.000 potrace.py:853(sign)
  ...
```

**After adding @numba.njit() to findnext():**
```
45923494 function calls (44621093 primitive calls) in 26.091 seconds

   Ordered by: cumulative time

   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
    481/1    0.002    0.000   26.103   26.103 {built-in method builtins.exec}
        1    0.064    0.064   26.103   26.103 test.py:1(<module>)
        1    0.071    0.071   25.788   25.788 test.py:6(file_to_svg)
        1    0.000    0.000   25.650   25.650 potrace.py:40(trace)
        1    0.020    0.020   14.359   14.359 potrace.py:1923(process_path)
        1    0.026    0.026   11.139   11.139 potrace.py:812(bm_to_pathlist)
     2988    7.186    0.002   10.198    0.003 potrace.py:1171(_calc_lon)
     3993    9.534    0.002    9.534    0.002 potrace.py:645(findnext)            <-- ~10 seconds spent here
     2988    0.493    0.000    2.675    0.001 potrace.py:1350(_bestpolygon)
  1185378    1.709    0.000    2.120    0.000 potrace.py:1307(penalty3)
 15840196    1.466    0.000    1.466    0.000 potrace.py:1009(xprod)
       49    0.001    0.000    0.800    0.016 __init__.py:1(<module>)
     3992    0.569    0.000    0.787    0.000 potrace.py:571(findpath)
     2988    0.334    0.000    0.767    0.000 potrace.py:1143(_calc_sums)
  8628578    0.759    0.000    0.759    0.000 potrace.py:855(sign)
  ...
```